### PR TITLE
feat: checkpoint 去重回复补充说明（自动快照基准 + git 未跟踪文件提示）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to dsh-checkpoint-rewind are documented here. The
 format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/);
 this project versions with [SemVer](https://semver.org/).
 
+## [Unreleased]
+
+### Changed
+
+- The checkpoint dedup reply no longer leaves the user guessing. When a manual `checkpoint` call is deduplicated (workspace tree identical to the latest snapshot), the message still says nothing new was captured, but now appends an explanation when one is warranted: if the dedup baseline is an automatic snapshot, it notes that the latest checkpoint (auto, seq) already records the exact workspace state — an auto snapshot may have just captured the same tree moments earlier, which previously made a successful dedup look like a failed capture; if the git provider sees untracked files, it notes that git snapshots only cover tracked files and suggests staging them with `git add` so future checkpoints include them. The hints are best-effort: a provider-side failure degrades silently to the plain message, and the copy provider (whole-directory snapshots, no untracked concept) never sees the git-only hint.
+- The git provider exposes a new optional read-only method `untrackedFiles(workspace)` (`git ls-files --others --exclude-standard`, the same whitelist verb restore/preview already use) so consumers can surface the tracked-only coverage gap; restore and preview reuse the extracted implementation.
+- Regression coverage: `test/index.test.mjs` pins the auto-snapshot hint (copy provider) and the untracked-files hint (real git repository, skip-guarded); `test/providers/git.test.mjs` pins the `untrackedFiles` method with a scripted runner (list + empty output).
+
 ## [0.5.3] — 2026-08-21
 
 ### Changed

--- a/index.mjs
+++ b/index.mjs
@@ -514,7 +514,8 @@ export async function apply(ctx, config = {}) {
       }
       if (result === null) {
         logger.debug(`checkpoint deduped: workspace unchanged (trigger ${opts.triggerTool})`)
-        return { deduped: true }
+        const detail = await dedupDetailOf(provider, previous, { cwd, key: workspaceKeyOf(cwd) })
+        return { deduped: true, detail }
       }
       const note = typeof opts.note === 'string' && opts.note.trim().length > 0
         ? opts.note.trim().slice(0, LIMITS.MAX_NOTE_LENGTH)
@@ -550,6 +551,41 @@ export async function apply(ctx, config = {}) {
       warn(`checkpoint capture failed (trigger ${opts.triggerTool}): ${messageOf(error)}`)
       return { failed: messageOf(error) }
     }
+  }
+
+  /**
+   * 去重时的补充说明（尽力而为；任何失败静默降级为空串，绝不阻断去重路径）：
+   * - git provider 存在未跟踪文件时提示纳管（git 快照只覆盖已跟踪文件，
+   *   未跟踪文件即使有改动也不会被捕获，用户需要 `git add` 纳入索引）；
+   * - 去重基准是自动快照时说明该状态已被自动快照记录（手动调用紧随自动
+   *   快照之后时会看到这条，避免"调用成功却无新记录"的困惑）。
+   * @param {import('./lib/providers/definition.mjs').SnapshotProvider} provider - 已解析的快照 provider。
+   * @param {object|undefined} previous - 去重基准记录（latestRecordFor 结果）。
+   * @param {{cwd: string, key: string}} workspace - 工作区。
+   * @returns {Promise<string>} 补充说明（多行或空串）。
+   */
+  async function dedupDetailOf(provider, previous, workspace) {
+    const lines = []
+    try {
+      if (typeof provider.untrackedFiles === 'function') {
+        const untracked = await provider.untrackedFiles(workspace)
+        if (untracked.length > 0) {
+          lines.push(`${untracked.length} untracked file(s) are not covered by git snapshots — stage them with \`git add\` to include them in future checkpoints`)
+        }
+      }
+    } catch (error) {
+      logger.debug(`checkpoint dedup hint: untracked scan failed (${messageOf(error)})`)
+    }
+    if (previous !== undefined && previous.triggerTool === 'auto') {
+      lines.push(`the latest checkpoint (#${String(previous.id).slice(0, 8)}, auto, seq ${previous.seq}) already records this exact workspace state`)
+    }
+    return lines.join('\n')
+  }
+
+  /** 去重结果文本：基础句 + 可选补充说明（多行）。 */
+  function dedupedCheckpointText(detail) {
+    const base = 'checkpoint: workspace unchanged since the last checkpoint — nothing new was captured'
+    return typeof detail === 'string' && detail.length > 0 ? `${base}\n${detail}` : base
   }
 
   /**
@@ -797,7 +833,7 @@ export async function apply(ctx, config = {}) {
               note: typeof args?.note === 'string' ? args.note : undefined,
             })
             if (result === undefined) return 'checkpoint: session has no workspace or no turn/step history yet'
-            if (result.deduped === true) return 'checkpoint: workspace unchanged since the last checkpoint — nothing new was captured'
+            if (result.deduped === true) return dedupedCheckpointText(result.detail)
             if (result.failed !== undefined) return `checkpoint: capture failed (${result.failed}) — no checkpoint was created`
             const record = result.record
             return [
@@ -1398,7 +1434,7 @@ export async function apply(ctx, config = {}) {
       return { kind: 'error', text: 'checkpoint: session has no workspace or no turn/step history yet' }
     }
     if (result.deduped === true) {
-      return { kind: 'success', text: 'checkpoint: workspace unchanged since the last checkpoint — nothing new was captured' }
+      return { kind: 'success', text: dedupedCheckpointText(result.detail) }
     }
     if (result.failed !== undefined) {
       return { kind: 'error', text: `checkpoint: capture failed (${result.failed}) — no checkpoint was created` }

--- a/lib/providers/definition.mjs
+++ b/lib/providers/definition.mjs
@@ -75,6 +75,10 @@
  *   显式 reset-hard 模式（git 专用）：git reset --hard <快照提交>。
  * @property {(workspace: WorkspaceInfo, fromRef: string, toRef: string) => Promise<DiffFilesResult>} [diffFiles]
  *   两个快照之间的文件变更集（纯读取）。
+ * @property {(workspace: WorkspaceInfo) => Promise<string[]>} [untrackedFiles]
+ *   未跟踪（非忽略）文件清单（git 专用：git 快照只覆盖已跟踪文件；copy 快照
+ *   覆盖整个工作区、无此概念）。供消费方在去重等场景给出可操作提示（如
+ *   "git add 纳入后续快照"）。
  * @property {(workspace: WorkspaceInfo, ref: string) => Promise<void>} discard
  *   删除 ref 占用的快照存储。
  * @property {(workspace: WorkspaceInfo, ref: string, signal?: AbortSignal) => Promise<PreviewResult>} [preview]

--- a/lib/providers/git.mjs
+++ b/lib/providers/git.mjs
@@ -161,6 +161,28 @@ export class GitSnapshotProvider {
   }
 
   /**
+   * 未跟踪（非忽略）文件清单：`git ls-files --others --exclude-standard`
+   * （只读，白名单动词）。无锁——restore/preview 已在同 key 锁内调用，
+   * 公开方法 untrackedFiles 负责加锁。
+   * @param {string} cwd - 仓库根。
+   * @returns {Promise<string[]>} 未跟踪路径清单（按 git 输出顺序）。
+   */
+  async #untracked(cwd) {
+    const out = (await this.#git(cwd, ['ls-files', '--others', '--exclude-standard'])).stdout
+    return out.split('\n').map(line => line.trim()).filter(line => line.length > 0)
+  }
+
+  /**
+   * 未跟踪（非忽略）文件清单（只读；去重提示用：git 快照只覆盖已跟踪文件，
+   * 消费方借此给出"git add 纳入后续快照"的可操作提示）。
+   * @param {import('./definition.mjs').WorkspaceInfo} workspace - 目标工作区。
+   * @returns {Promise<string[]>} 未跟踪路径清单。
+   */
+  async untrackedFiles(workspace) {
+    return withLock(this.#chains, workspace.key, async () => this.#untracked(workspace.cwd))
+  }
+
+  /**
    * 捕获当前状态为未引用的提交对象。与 previousRef 树一致时返回 null（去重）。
    * bytes 是增量记账：相对父提交变更文件（真正写入 odb 的 blob）的字节和，
    * 不是整棵树——干净树的快照字节接近 0。
@@ -230,8 +252,7 @@ export class GitSnapshotProvider {
       }
       // 遗留报告：未跟踪新文件 ∪ 检查点后新增且已进入索引的文件（工作树相对
       // ref 的新增路径）——都只报告、不删除，与 copy provider 对称。
-      const untracked = (await this.#git(workspace.cwd, ['ls-files', '--others', '--exclude-standard'])).stdout
-        .trim().split('\n').filter(line => line.length > 0)
+      const untracked = await this.#untracked(workspace.cwd)
       const added = (await this.#git(workspace.cwd, ['diff', '--name-only', '--diff-filter=A', ref, '--'])).stdout
         .trim().split('\n').filter(line => line.length > 0)
       const leftovers = [...new Set([...untracked, ...added])].sort()
@@ -262,8 +283,7 @@ export class GitSnapshotProvider {
         .trim().split('\n').filter(line => line.length > 0)
       const trackedSet = new Set(tracked)
       const changes = changed.filter(name => trackedSet.has(name)).sort()
-      const untracked = (await this.#git(workspace.cwd, ['ls-files', '--others', '--exclude-standard'])).stdout
-        .trim().split('\n').filter(line => line.length > 0)
+      const untracked = await this.#untracked(workspace.cwd)
       const added = (await this.#git(workspace.cwd, ['diff', '--name-only', '--diff-filter=A', ref, '--'])).stdout
         .trim().split('\n').filter(line => line.length > 0)
       const leftovers = [...new Set([...untracked, ...added])].sort()
@@ -319,8 +339,7 @@ export class GitSnapshotProvider {
       if (applied.code !== 0) {
         throw providerFailed(PROVIDERS.GIT, 'reset', applied.stderr.trim() || `git reset exited ${applied.code}`)
       }
-      const untracked = (await this.#git(workspace.cwd, ['ls-files', '--others', '--exclude-standard'])).stdout
-        .trim().split('\n').filter(line => line.length > 0)
+      const untracked = await this.#untracked(workspace.cwd)
       return {
         restored: changed.length,
         leftovers: untracked,

--- a/test/index.test.mjs
+++ b/test/index.test.mjs
@@ -4,6 +4,7 @@
 
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
+import { spawn } from 'node:child_process'
 import fs from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
@@ -865,6 +866,62 @@ describe('/checkpoint 命令', () => {
     assert.ok(Array.isArray(manual.config) === false && typeof manual.config === 'object', '记录携带配置快照')
     assert.equal(manual.config.provider, 'copy')
     await app.dispose()
+  })
+
+  it('去重且最新记录为自动快照：消息说明该状态已被自动快照记录', async () => {
+    const cwd = await makeWorkspace({ 'a.txt': 'A1' })
+    const snapshotDir = await makeSnapDir()
+    const app = await mountPlugin({ cwd, config: { provider: 'copy', snapshotDir, autoCheckpoint: { enabled: true, intervalMinutes: 0 } } })
+    openStep(app.session, 1, 1)
+    await waitForRecords(app.records, 1)
+    const deduped = await command(app, '/checkpoint')
+    assert.equal(deduped?.result.kind, 'success')
+    assert.match(deduped?.result.text, /nothing new was captured/)
+    assert.match(deduped?.result.text, /already records this exact workspace state/)
+    assert.match(deduped?.result.text, /\(#[0-9a-f]{8}, auto, seq \d+\)/)
+    assert.doesNotMatch(deduped?.result.text, /untracked/, 'copy provider 无未跟踪概念')
+    await app.dispose()
+  })
+
+  it('去重且存在未跟踪文件（git provider）：消息提示 git add 纳管', async (t) => {
+    const repo = await fs.mkdtemp(path.join(os.tmpdir(), 'dsh-rewind-cp-'))
+    const runReal = async (args) => {
+      const result = await new Promise((resolve, reject) => {
+        const child = spawn('git', args, { cwd: repo, stdio: ['ignore', 'pipe', 'pipe'], windowsHide: true })
+        let stdout = ''
+        let stderr = ''
+        child.stdout.on('data', (c) => { stdout += String(c) })
+        child.stderr.on('data', (c) => { stderr += String(c) })
+        child.on('error', reject)
+        child.on('close', (code) => resolve({ code: code ?? 0, stdout, stderr }))
+      })
+      return result
+    }
+    const init = await runReal(['init', '-q']).catch((error) => {
+      t.skip(`git init unavailable (${error.message})`)
+      return undefined
+    })
+    if (init === undefined) return
+    await runReal(['config', 'user.email', 'test@example.com'])
+    await runReal(['config', 'user.name', 'tester'])
+    await runReal(['config', 'core.autocrlf', 'false'])
+    await fs.writeFile(path.join(repo, 'a.txt'), 'A1')
+    await runReal(['add', '-A'])
+    await runReal(['commit', '-q', '-m', 'initial'])
+    const snapshotDir = await makeSnapDir()
+    const app = await mountPlugin({ cwd: repo, config: { provider: 'git', snapshotDir } })
+    openStep(app.session, 1, 1)
+    await dispatchWriteIntent(app.root, app.agent, 'bash')
+    await waitForRecords(app.records, 1)
+    await fs.writeFile(path.join(repo, 'untracked.txt'), 'not covered\n')
+    const deduped = await command(app, '/checkpoint')
+    assert.equal(deduped?.result.kind, 'success')
+    assert.match(deduped?.result.text, /nothing new was captured/)
+    assert.match(deduped?.result.text, /1 untracked file\(s\) are not covered by git snapshots/)
+    assert.match(deduped?.result.text, /git add/)
+    assert.doesNotMatch(deduped?.result.text, /already records this exact workspace state/, '基准是变更快照而非自动快照')
+    await app.dispose()
+    await fs.rm(repo, { recursive: true, force: true })
   })
 
   it('/checkpoint list 与 /checkpoint diff <a> <b>（文件/配置/会话差）', async () => {

--- a/test/providers/git.test.mjs
+++ b/test/providers/git.test.mjs
@@ -335,6 +335,26 @@ describe('git provider（scripted runner）', () => {
     assert.deepEqual(result, { changed: 3, added: 1, removed: 1, names: ['a.txt', 'gone.txt', 'new.txt'] })
     assert.equal(calls.some((args) => args[0] === 'restore' || args[0] === 'reset'), false, 'diffFiles 绝不写工作区')
   })
+
+  it('untrackedFiles：ls-files --others --exclude-standard 只读清单', async () => {
+    const { run, calls } = scriptedGit({
+      'ls-files --others --exclude-standard': { code: 0, stdout: 'new.txt\nsub/dir.txt\n', stderr: '' },
+    })
+    const provider = makeGitProvider({ gitBin: 'git', run })
+    const result = await provider.untrackedFiles(workspace)
+    assert.deepEqual(result, ['new.txt', 'sub/dir.txt'])
+    assert.deepEqual(calls, [['ls-files', '--others', '--exclude-standard']])
+  })
+
+  it('untrackedFiles：空输出返回空清单（无未跟踪文件）', async () => {
+    const { run, calls } = scriptedGit({
+      'ls-files --others --exclude-standard': { code: 0, stdout: '', stderr: '' },
+    })
+    const provider = makeGitProvider({ gitBin: 'git', run })
+    const result = await provider.untrackedFiles(workspace)
+    assert.deepEqual(result, [])
+    assert.deepEqual(calls, [['ls-files', '--others', '--exclude-standard']])
+  })
 })
 
 describe('git provider（真实 git，能力检测）', () => {


### PR DESCRIPTION
## Checklist

- [x] CI gate is green (`npm test` and `npm run test:integration` pass locally; CI status checks pass)
- [x] Tests added or updated for the change (`test/**/*.test.mjs`)
- [x] CHANGELOG.md updated (Added / Changed / Fixed under the right version)
- [x] All five READMEs synced (README.md is the source; README.zh.md / README.es.md / README.pt.md / README.hi.md updated in the same PR) — the checkpoint reply texts are not documented in the READMEs, so no sync was needed
- [ ] Related issue linked (`fixes #<n>` / `closes #<n>`) if one exists
- [x] No secrets: the diff contains no tokens, API keys, credentials, or real user workspace data (redact any sample with `<redacted>`)

## Summary

The checkpoint dedup reply no longer leaves the user guessing. When a manual `checkpoint` call is deduplicated (workspace tree identical to the latest snapshot), the message still says nothing new was captured but now appends best-effort hints when warranted:

- **Auto-snapshot baseline**: if the dedup baseline is an automatic snapshot, it notes that the latest checkpoint (`#<id8>, auto, seq N`) already records this exact workspace state — an auto snapshot may have captured the same tree moments earlier, which previously made a successful dedup look like a failed capture.
- **Git untracked files**: if the git provider sees untracked files, it notes that git snapshots only cover tracked files and suggests `git add` so future checkpoints include them.

Both hints are best-effort: a provider-side failure degrades silently to the plain message, and the copy provider (whole-directory snapshots, no untracked concept) never sees the git-only hint. The git provider exposes a new optional read-only method `untrackedFiles(workspace)` (`git ls-files --others --exclude-standard`, the same whitelist verb restore/preview already use); restore and preview reuse the extracted implementation.

Regression coverage: `test/index.test.mjs` pins the auto-snapshot hint (copy provider) and the untracked-files hint (real git repo, skip-guarded); `test/providers/git.test.mjs` pins `untrackedFiles` with a scripted runner (list + empty output).

## Safety checklist (changes that touch behavior)

- [x] Restore paths stay inside the approved-confirmation gate (never silently allow)
- [x] Git primitives stay within the side-effect-free whitelist (no reset --hard / clean / index or history mutation) — `ls-files --others --exclude-standard` is already whitelisted, now extracted and exposed read-only
- [x] New code is registered through ctx.effect() / ctx.on() / service register() (reversible lifecycle)
- [x] Any new module imported by index.mjs is added to package.json `files`