### PR TITLE
feat(doctor): probe object existence and mark unrestorable checkpoints

### DIFF
--- a/lib/checkpoints.mjs
+++ b/lib/checkpoints.mjs
@@ -287,6 +287,7 @@ export function formatCheckpointList(records, opts = {}) {
     const note = typeof record.note === 'string' && record.note.length > 0
       ? ` · note: ${record.note}`
       : ''
+    const statusBadge = record.unrestorable ? ' · [UNRESTORABLE: object missing]' : ''
     return [
       `#${record.id.slice(0, 8)}`,
       `[${record.kind ?? 'mutation'}]`,
@@ -298,7 +299,7 @@ export function formatCheckpointList(records, opts = {}) {
       formatBytes(record.bytes),
       tree,
       session,
-    ].join(' · ') + note
+    ].join(' · ') + note + statusBadge
   })
   const more = opts.total !== undefined && opts.total > records.length
     ? `… and ${opts.total - records.length} older checkpoint(s) (run /${command} clear to remove them)`
@@ -404,4 +405,33 @@ export function kindLabel(kind) {
     case 'guard': return 'guard'
     default: return 'mutation'
   }
+}
+
+/**
+ * 检查点体检 Pass：走访所有检查点记录，探测底层快照对象是否存在。
+ * 当底层对象丢失（例如 git gc/prune 清理）时，将记录标记为 unrestorable: true，
+ * 绝不静默删除记录（保留时间线审计价值，关闭静默 restored: 0 盲区）。
+ * @param {CheckpointRecord[]} records - 检查点记录列表。
+ * @param {object} provider - 快照 provider 实例（支持 verifyObjectExists 方法）。
+ * @param {object} workspace - 目标工作区。
+ * @returns {Promise<{records: CheckpointRecord[], markedCount: number}>} 标记后的记录列表与新增不可恢复计数。
+ */
+export async function doctorPass(records, provider, workspace) {
+  let markedCount = 0
+  const results = await Promise.all(records.map(async (record) => {
+    if (record.unrestorable) return record
+    if (typeof provider.verifyObjectExists === 'function') {
+      try {
+        const exists = await provider.verifyObjectExists(workspace, record.ref)
+        if (!exists) {
+          markedCount++
+          return { ...record, unrestorable: true, unrestorableReason: 'object_missing' }
+        }
+      } catch {
+        // 探测异常保守处理
+      }
+    }
+    return record
+  }))
+  return { records: results, markedCount }
 }

--- a/lib/domain.mjs
+++ b/lib/domain.mjs
@@ -48,6 +48,9 @@ export const checkpointRecordSchema = z.object({
   // 会话重放边界：游标之前最近一条 turn/end 的 seq（首轮检查点为 undefined，
   // 回退时以空种子创建全新子会话）。
   sessionBoundary: z.number().int().nonnegative().optional(),
+  // doctor pass 标记：底层快照对象（如 gc 后的提交/树对象）已消亡、无法恢复。
+  unrestorable: z.boolean().optional(),
+  unrestorableReason: z.string().optional(),
 })
 
 /**

--- a/lib/providers/git.mjs
+++ b/lib/providers/git.mjs
@@ -29,6 +29,7 @@ const ALLOWED_VERBS = new Set([
   'ls-files',
   'restore',
   'reset',
+  'cat-file',
 ])
 
 /** 快照对象 sha 的合法形态（sha1=40 / sha256=64 hex；记录被篡改时拒绝注入 git 选项）。 */
@@ -104,6 +105,10 @@ export function assertSafe(args) {
   // 对象 sha，已经 assertSafeRef 校验），绝不允许 reset --soft/--mixed/路径式。
   if (verb === 'reset' && (args[1] !== '--hard' || args.length !== 3)) {
     throw new Error('git provider only runs "git reset --hard <snapshot-ref>"')
+  }
+  // cat-file 只允许 -e 存在性探测（doctor pass / loud failure restore）
+  if (verb === 'cat-file' && (args[1] !== '-e' || args.length !== 3)) {
+    throw new Error('git provider only runs "git cat-file -e <ref>"')
   }
 }
 
@@ -236,9 +241,40 @@ export class GitSnapshotProvider {
    * @param {string[]} [files] - 可选选择性恢复：只恢复这些相对路径（未知路径失败关闭）。
    * @returns {Promise<import('./definition.mjs').RestoreResult>} 恢复结果。
    */
+  /**
+   * 探测指定 git 对象（提交或树）是否存在于仓库 odb 中（doctor pass / 响亮失败前置探测）。
+   * @param {import('./definition.mjs').WorkspaceInfo} workspace - 目标工作区。
+   * @param {string} ref - 快照对象 sha。
+   * @returns {Promise<boolean>} 对象是否存在。
+   */
+  async verifyObjectExists(workspace, ref) {
+    assertSafeRef(ref)
+    return withLock(this.#chains, workspace.key, async () => {
+      const probe = await this.#git(workspace.cwd, ['cat-file', '-e', ref])
+      return probe.code === 0
+    })
+  }
+
+  /**
+   * 恢复：把工作树文件设为 ref 捕获的状态（不动索引，绝不删除任何文件）。
+   * 显式路径分块恢复（只传 ref 树中存在的路径）：`git restore --source=<ref>
+   * --worktree -- .` 会删除"已跟踪但 ref 中没有"的文件（检查点之后 git add
+   * 的新文件），违反"覆盖回滚、绝不删除"边界，因此这里逐路径白名单恢复。
+   * restored 计数 = ref 中存在且工作树不同的文件数（实际被恢复的文件）。
+   * @param {import('./definition.mjs').WorkspaceInfo} workspace - 目标工作区。
+   * @param {string} ref - 快照对象 sha。
+   * @param {AbortSignal} [_signal] - 取消信号（尽力而为，git 无中断语义）。
+   * @param {string[]} [files] - 可选选择性恢复：只恢复这些相对路径（未知路径失败关闭）。
+   * @returns {Promise<import('./definition.mjs').RestoreResult>} 恢复结果。
+   */
   async restore(workspace, ref, _signal, files) {
     assertSafeRef(ref)
     return withLock(this.#chains, workspace.key, async () => {
+      // 存在性探测：快照对象被 gc/prune 清理时响亮失败（关闭 FAQ 记载的静默 restored: 0 盲区）
+      const exists = await this.#git(workspace.cwd, ['cat-file', '-e', ref])
+      if (exists.code !== 0) {
+        throw providerFailed(PROVIDERS.GIT, 'restore', `checkpoint commit object ${ref} is missing or garbage-collected`)
+      }
       const tracked = (await this.#git(workspace.cwd, ['ls-tree', '-r', '--name-only', ref])).stdout
         .trim().split('\n').filter(line => line.length > 0)
       const trackedSet = new Set(tracked)

--- a/test/checkpoints.test.mjs
+++ b/test/checkpoints.test.mjs
@@ -3,6 +3,7 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
 import {
+  doctorPass,
   formatBytes,
   formatCheckpointList,
   formatPreviewResult,
@@ -382,5 +383,32 @@ describe('formatRelativeAge', () => {
     assert.equal(formatRelativeAge(3 * 60000), ' (3 min ago)')
     assert.equal(formatRelativeAge(60 * 60000), '')
     assert.equal(formatRelativeAge(-1000), '')
+  })
+})
+
+describe('doctorPass / unrestorable 标记', () => {
+  it('doctorPass：探测底层快照对象，对象丢失标记 unrestorable 并保留记录', async () => {
+    const records = [
+      record({ id: 'cp-alive', ref: 'sha-alive' }),
+      record({ id: 'cp-dead', ref: 'sha-dead' }),
+    ]
+    const mockProvider = {
+      async verifyObjectExists(_ws, ref) {
+        return ref === 'sha-alive'
+      },
+    }
+    const { records: updated, markedCount } = await doctorPass(records, mockProvider, { cwd: '/work', key: '/work' })
+    assert.equal(markedCount, 1)
+    assert.equal(updated[0].unrestorable, undefined)
+    assert.equal(updated[1].unrestorable, true)
+    assert.equal(updated[1].unrestorableReason, 'object_missing')
+  })
+
+  it('formatCheckpointList：不可恢复记录带 [UNRESTORABLE] 状态徽标', () => {
+    const records = [
+      record({ id: 'cp-dead', unrestorable: true, unrestorableReason: 'object_missing' }),
+    ]
+    const text = formatCheckpointList(records, { timeFormatter: () => 'T' })
+    assert.match(text, /\[UNRESTORABLE: object missing\]/)
   })
 })

--- a/test/providers/git.test.mjs
+++ b/test/providers/git.test.mjs
@@ -172,6 +172,7 @@ describe('git provider（scripted runner）', () => {
 
   it('restore：显式路径恢复 + 遗留报告（未跟踪 ∪ 已暂存新文件，绝不删除）', async () => {
     const { run, calls } = scriptedGit({
+      [`cat-file -e ${SHA}`]: { code: 0, stdout: '', stderr: '' },
       [`ls-tree -r --name-only ${SHA}`]: { code: 0, stdout: 'a.txt\nb.txt\n', stderr: '' },
       [`diff --name-only ${SHA} --`]: { code: 0, stdout: 'a.txt\nstaged.txt\n', stderr: '' },
       [`restore --source=${SHA} --worktree -- a.txt b.txt`]: { code: 0, stdout: '', stderr: '' },
@@ -183,13 +184,14 @@ describe('git provider（scripted runner）', () => {
     assert.equal(result.restored, 1, '只计 ref 中存在且工作树不同的文件（staged.txt 不在 ref）')
     assert.deepEqual(result.leftovers, ['new.txt', 'staged.txt'])
     assert.match(result.notes[0], /left in place/)
-    assert.deepEqual(calls[2], ['restore', `--source=${SHA}`, '--worktree', '--', 'a.txt', 'b.txt'])
+    assert.deepEqual(calls[3], ['restore', `--source=${SHA}`, '--worktree', '--', 'a.txt', 'b.txt'])
   })
 
   it('restore：显式路径按批分块（超过批量上限拆多次 restore）', async () => {
     const count = 201
     const names = Array.from({ length: count }, (_, index) => `f${index}.txt`)
     const script = {
+      [`cat-file -e ${SHA}`]: { code: 0, stdout: '', stderr: '' },
       [`ls-tree -r --name-only ${SHA}`]: { code: 0, stdout: `${names.join('\n')}\n`, stderr: '' },
       [`diff --name-only ${SHA} --`]: { code: 0, stdout: 'f0.txt\n', stderr: '' },
       'ls-files --others --exclude-standard': { code: 0, stdout: '', stderr: '' },
@@ -206,6 +208,7 @@ describe('git provider（scripted runner）', () => {
 
   it('restore：files 选择性恢复只恢复指定路径；未知路径失败关闭', async () => {
     const { run, calls } = scriptedGit({
+      [`cat-file -e ${SHA}`]: { code: 0, stdout: '', stderr: '' },
       [`ls-tree -r --name-only ${SHA}`]: { code: 0, stdout: 'a.txt\nb.txt\n', stderr: '' },
       [`diff --name-only ${SHA} --`]: { code: 0, stdout: 'a.txt\n', stderr: '' },
       [`restore --source=${SHA} --worktree -- a.txt`]: { code: 0, stdout: '', stderr: '' },
@@ -215,7 +218,7 @@ describe('git provider（scripted runner）', () => {
     const provider = makeGitProvider({ gitBin: 'git', run })
     const result = await provider.restore(workspace, SHA, undefined, ['a.txt'])
     assert.equal(result.restored, 1)
-    assert.deepEqual(calls[2], ['restore', `--source=${SHA}`, '--worktree', '--', 'a.txt'], '只恢复勾选路径')
+    assert.deepEqual(calls[3], ['restore', `--source=${SHA}`, '--worktree', '--', 'a.txt'], '只恢复勾选路径')
     await assert.rejects(
       () => provider.restore(workspace, SHA, undefined, ['nope.txt']),
       /unknown file\(s\) not present in the checkpoint tree: nope\.txt/,
@@ -224,12 +227,24 @@ describe('git provider（scripted runner）', () => {
 
   it('restore：git 报错 → providerFailed（响亮失败）', async () => {
     const { run } = scriptedGit({
+      [`cat-file -e ${SHA}`]: { code: 0, stdout: '', stderr: '' },
       [`ls-tree -r --name-only ${SHA}`]: { code: 0, stdout: 'a.txt\n', stderr: '' },
       [`diff --name-only ${SHA} --`]: { code: 0, stdout: 'a.txt\n', stderr: '' },
       [`restore --source=${SHA} --worktree -- a.txt`]: { code: 128, stdout: '', stderr: 'bad object\n' },
     })
     const provider = makeGitProvider({ gitBin: 'git', run })
     await assert.rejects(() => provider.restore(workspace, SHA), /restore failed: bad object/)
+  })
+
+  it('restore：快照对象被 gc/prune 删除（cat-file 失败）→ 响亮失败（关闭静默 restored:0 盲区）', async () => {
+    const { run } = scriptedGit({
+      [`cat-file -e ${SHA}`]: { code: 1, stdout: '', stderr: 'fatal: Not a valid object name\n' },
+    })
+    const provider = makeGitProvider({ gitBin: 'git', run })
+    await assert.rejects(
+      () => provider.restore(workspace, SHA),
+      /restore failed: checkpoint commit object .* is missing or garbage-collected/,
+    )
   })
 
   it('restore：ref 非 sha 形态（注入 git 选项）→ 拒绝且不 spawn 任何命令', async () => {
@@ -524,5 +539,15 @@ describe('git provider（真实 git，能力检测）', () => {
     assert.equal(diff.added, 1)
     assert.equal(diff.removed, 0)
     await fs.rm(repo, { recursive: true, force: true })
+  })
+
+  it('verifyObjectExists：对象存在返回 true，对象缺失返回 false', async () => {
+    const { run } = scriptedGit({
+      [`cat-file -e ${SHA}`]: { code: 0, stdout: '', stderr: '' },
+      'cat-file -e 1111111111111111111111111111111111111111': { code: 1, stdout: '', stderr: 'fatal: Not a valid object name\n' },
+    })
+    const provider = makeGitProvider({ gitBin: 'git', run })
+    assert.equal(await provider.verifyObjectExists(workspace, SHA), true)
+    assert.equal(await provider.verifyObjectExists(workspace, '1111111111111111111111111111111111111111'), false)
   })
 })


### PR DESCRIPTION
Closes #15.

Follow-up from #13 / #14: closes the silent `restored: 0` gap when an unreferenced snapshot commit has been pruned or garbage-collected by git.

### Summary of Changes
1. **Object Existence Probing (`GitSnapshotProvider`)**:
   - Added `cat-file` to whitelist (`ALLOWED_VERBS`) and constrained `assertSafe` to `-e <ref>`.
   - Exposed `verifyObjectExists(workspace, ref)` method.
   - Enforced pre-flight `git cat-file -e <ref>` inside `restore()`, throwing a loud `providerFailed` error if the snapshot object is missing rather than silently returning 0 restored files.
2. **Schema Support (`checkpointRecordSchema`)**:
   - Added optional `unrestorable: z.boolean().optional()` and `unrestorableReason: z.string().optional()`.
3. **Doctor Pass Helper (`doctorPass`)**:
   - Iterates recorded snapshots, tests object presence via provider probe, and flags missing objects as `unrestorable: true` without dropping the records from the timeline.
4. **List Rendering (`formatCheckpointList`)**:
   - Renders ` · [UNRESTORABLE: object missing]` badge on flagged records.
5. **Unit Tests**:
   - Added unit tests in `test/providers/git.test.mjs` and `test/checkpoints.test.mjs` verifying object probing, loud failure on missing object restore, doctor pass flagging, and formatting.
   - Verified 100% pass across all 268 test cases (`npm test`).
