### PR TITLE
fix(providers): consume liveConfig for snapshotDir, excludeGlobs, and verifyByHash (#12)

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -319,16 +319,19 @@ export async function apply(ctx, config = {}) {
 
   // --- provider seam：两个 provider 经 registry 注册（注册即 effect，卸载撤销）。
   const registry = new SnapshotProviderRegistry()
-  const unregGit = registry.register(makeGitProvider({ gitBin: resolved.gitBin }))
+  const unregGit = registry.register(makeGitProvider({ gitBin: () => liveConfig.gitBin }))
   let snapshotDirCache
   const getSnapshotDir = () => {
-    if (snapshotDirCache === undefined) snapshotDirCache = resolveSnapshotDir(resolved.snapshotDir)
+    if (snapshotDirCache === undefined) snapshotDirCache = resolveSnapshotDir(liveConfig.snapshotDir)
     return snapshotDirCache
   }
+  onLiveChange(() => {
+    snapshotDirCache = undefined
+  })
   const unregCopy = registry.register(makeCopyProvider({
     snapshotDir: getSnapshotDir,
-    excludeGlobs: resolved.excludeGlobs,
-    verifyByHash: resolved.verifyByHash,
+    excludeGlobs: () => liveConfig.excludeGlobs,
+    verifyByHash: () => liveConfig.verifyByHash,
   }))
   ctx.effect(() => () => {
     unregGit()

--- a/lib/providers/copy.mjs
+++ b/lib/providers/copy.mjs
@@ -140,8 +140,10 @@ export class CopySnapshotProvider {
    */
   constructor(deps) {
     this.#snapshotDir = typeof deps.snapshotDir === 'function' ? deps.snapshotDir : () => path.resolve(deps.snapshotDir)
-    this.#excluded = makeExcluder(deps.excludeGlobs ?? [])
-    this.#verifyByHash = deps.verifyByHash === true
+    this.#excluded = typeof deps.excludeGlobs === 'function'
+      ? (relPath) => makeExcluder(deps.excludeGlobs() ?? [])(relPath)
+      : makeExcluder(deps.excludeGlobs ?? [])
+    this.#verifyByHash = typeof deps.verifyByHash === 'function' ? deps.verifyByHash : () => deps.verifyByHash === true
   }
 
   get name() {
@@ -457,7 +459,7 @@ export class CopySnapshotProvider {
         }
         const rel = relPath
         let hash
-        if (this.#verifyByHash) {
+        if (this.#verifyByHash()) {
           try {
             hash = await hashFile(abs)
           } catch (error) {

--- a/lib/providers/git.mjs
+++ b/lib/providers/git.mjs
@@ -73,7 +73,8 @@ function chunkList(items, size) {
  */
 export function spawnGitRunner(gitBin) {
   return (args, opts = {}) => new Promise((resolve, reject) => {
-    const child = spawn(gitBin, args, {
+    const bin = typeof gitBin === 'function' ? gitBin() : gitBin
+    const child = spawn(bin, args, {
       cwd: opts.cwd,
       stdio: ['ignore', 'pipe', 'pipe'],
       windowsHide: true,

--- a/test/providers/copy.test.mjs
+++ b/test/providers/copy.test.mjs
@@ -416,4 +416,33 @@ describe('copy provider', () => {
     const { provider } = await makeProvider()
     await assert.rejects(() => provider.preview({ cwd, key: cwd }, '../evil'), /not a safe snapshot id/)
   })
+
+  it('dynamic getter: excludeGlobs and snapshotDir update without provider reconstruction', async () => {
+    const cwd = await makeWorkspace({ 'keep.txt': 'K', 'ignore1.log': 'L1', 'ignore2.tmp': 'T2' })
+    let currentExclude = ['*.log']
+    let currentSnapDir = await fs.mkdtemp(path.join(os.tmpdir(), 'dsh-snap-dyn1-'))
+    const provider = makeCopyProvider({
+      snapshotDir: () => currentSnapDir,
+      excludeGlobs: () => currentExclude,
+    })
+    const ws = { cwd, key: cwd }
+
+    // First snapshot with currentExclude = ['*.log']
+    const snap1 = await provider.snapshot(ws, { triggerTool: 'bash' })
+    const manifest1 = JSON.parse(await fs.readFile(path.join(snapshotBaseDir(currentSnapDir, cwd), snap1.ref, 'manifest.json'), 'utf8'))
+    assert.deepEqual(manifest1.files.map((e) => e.rel).sort(), ['ignore2.tmp', 'keep.txt'])
+
+    // Update exclude dynamically to ['*.tmp']
+    currentExclude = ['*.tmp']
+    const snap2 = await provider.snapshot(ws, { triggerTool: 'bash' })
+    const manifest2 = JSON.parse(await fs.readFile(path.join(snapshotBaseDir(currentSnapDir, cwd), snap2.ref, 'manifest.json'), 'utf8'))
+    assert.deepEqual(manifest2.files.map((e) => e.rel).sort(), ['ignore1.log', 'keep.txt'])
+
+    // Update snapshotDir dynamically
+    const nextSnapDir = await fs.mkdtemp(path.join(os.tmpdir(), 'dsh-snap-dyn2-'))
+    currentSnapDir = nextSnapDir
+    const snap3 = await provider.snapshot(ws, { triggerTool: 'bash' })
+    const manifest3 = JSON.parse(await fs.readFile(path.join(snapshotBaseDir(nextSnapDir, cwd), snap3.ref, 'manifest.json'), 'utf8'))
+    assert.ok(manifest3.id, 'snapshot written to dynamic snapshot directory')
+  })
 })


### PR DESCRIPTION
Fixes #12

### Problem Summary
\snapshotDir\, \excludeGlobs\, \erifyByHash\, and \gitBin\ were read only once from initial entry config (\esolved\) when registering providers, ignoring live configuration changes updated via the settings namespace or \/rewind config\ (#12).

### Changes
1. **Dynamic cache invalidation**: Reset \snapshotDirCache\ on \onLiveChange\ and resolve against \liveConfig.snapshotDir\.
2. **Provider getter support**: Updated \CopySnapshotProvider\ and \GitSnapshotProvider\ to evaluate dynamic getters for \excludeGlobs\, \erifyByHash\, and \gitBin\.
3. **Test coverage**: Added \dynamic getter: excludeGlobs and snapshotDir update without provider reconstruction\ test in \	est/providers/copy.test.mjs\. All 265 tests passing.