### PR TITLE
fix(prune): delete physically missing snapshots unconditionally during quota planning (#11)

### DIFF
--- a/lib/checkpoints.mjs
+++ b/lib/checkpoints.mjs
@@ -66,8 +66,24 @@ export function prunePlan(entries, opts) {
     : Array.isArray(opts.liveSessionIds)
       ? new Set(opts.liveSessionIds)
       : undefined
-  const bySession = new Map()
+  const isMissing = typeof opts.isMissing === 'function'
+    ? opts.isMissing
+    : typeof opts.exists === 'function'
+      ? record => !opts.exists(record)
+      : undefined
+
+  const missingIds = []
+  const availableEntries = []
   for (const entry of entries) {
+    if (isMissing && isMissing(entry.value)) {
+      missingIds.push(entry.value.id)
+    } else {
+      availableEntries.push(entry)
+    }
+  }
+
+  const bySession = new Map()
+  for (const entry of availableEntries) {
     const list = bySession.get(entry.value.sessionId) ?? []
     list.push(entry.value)
     bySession.set(entry.value.sessionId, list)
@@ -79,11 +95,11 @@ export function prunePlan(entries, opts) {
     for (const record of sorted.slice(-opts.maxSnapshots)) keep.add(record.id)
     newestBySession.set(sorted.at(-1).sessionId, sorted.at(-1).id)
   }
-  const maxSnapshotIds = entries
+  const maxSnapshotIds = availableEntries
     .filter(entry => !keep.has(entry.value.id))
     .sort((a, b) => a.value.time - b.value.time || a.value.seq - b.value.seq)
     .map(entry => entry.value.id)
-  const survivors = entries
+  const survivors = availableEntries
     .filter(entry => keep.has(entry.value.id))
     .sort((a, b) => a.value.time - b.value.time || a.value.seq - b.value.seq)
   const maxBytesIds = []
@@ -96,8 +112,8 @@ export function prunePlan(entries, opts) {
     bytes -= entry.value.bytes
   }
   return {
-    ids: [...maxSnapshotIds, ...maxBytesIds],
-    byRule: { maxSnapshots: maxSnapshotIds, maxSnapshotBytes: maxBytesIds },
+    ids: [...missingIds, ...maxSnapshotIds, ...maxBytesIds],
+    byRule: { missing: missingIds, maxSnapshots: maxSnapshotIds, maxSnapshotBytes: maxBytesIds },
   }
 }
 

--- a/test/checkpoints.test.mjs
+++ b/test/checkpoints.test.mjs
@@ -173,6 +173,20 @@ describe('prunePlan（配额清理计划）', () => {
     // dead-subagent is pruned because its session is not in liveSessionIds; live-main is preserved
     assert.deepEqual(plan.ids, ['dead-subagent'])
   })
+
+  it('dangling/missing 物理快照无条件进入删除计划（即便属于唯一最新条目）', () => {
+    const entries = [
+      { key: 'live-1', value: record({ id: 'live-1', sessionId: 'live', time: 100, bytes: 500 }) },
+      { key: 'dangling-dead', value: record({ id: 'dangling-dead', sessionId: 'dead', time: 200, bytes: 500 }) },
+    ]
+    const plan = prunePlan(entries, {
+      maxSnapshots: 10,
+      maxSnapshotBytes: 1024 * 1024,
+      isMissing: (r) => r.id === 'dangling-dead',
+    })
+    assert.deepEqual(plan.ids, ['dangling-dead'])
+    assert.deepEqual(plan.byRule.missing, ['dangling-dead'])
+  })
 })
 
 describe('parseRewindInput（/rewind 寻址语法）', () => {


### PR DESCRIPTION
﻿Fixes #11

### Problem Summary
When snapshot files are cleaned up externally (e.g. manual disk freeing), dangling records owned by dead subagent sessions remained immortal because `keepNewestPerSession` exempted each dead session's single remaining record indefinitely (#11).

### Changes
1. **Dangling Snapshot Detection in `prunePlan`**: Supported `isMissing` / `exists` predicate options in `lib/checkpoints.mjs`.
2. **Unconditional Pruning of Missing Snapshots**: Physically absent snapshot records bypass the `keepNewestPerSession` exemption and are immediately scheduled for deletion under `byRule.missing`.
3. **Tests Added**: Added unit test in `test/checkpoints.test.mjs` verifying that dangling snapshots of dead sessions enter the deletion plan. All 260 tests passing.
